### PR TITLE
Update index.js to set a default layout which does not cause white screen issue after loading

### DIFF
--- a/admin/src/pages/Dashboard/index.js
+++ b/admin/src/pages/Dashboard/index.js
@@ -52,7 +52,7 @@ function Dashboard() {
   const [team, setTeam] = useState({});
   const [teams, setTeams] = useState([]);
   const [dropdownTeam, setDropdownTeam] = useState('');
-  const [layouts, setLayouts] = useState(null);
+  const [layouts, setLayouts] = useState({ xxs: [], xs: [], sm: [], md: [], lg: [] });
 
   useEffect(() => {
     getSettings().then((data) => setStore(data));


### PR DESCRIPTION
When loading the plugin for the first time, after setLoading is false, the screen goes blank because setLayouts can be null by default. So initializing it with empty values solves the problem.